### PR TITLE
Change ref file back to original in 001

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# vcfeval_hap.py v1.0
+# vcfeval_hap.py v1.0.0
 
 ## hap.py version
  Based on moka_guys/vcfeval_hap.py [v0.3.9] (Docker: https://hub.docker.com/r/pkrusche/hap.py/)

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "vcfeval_hap.py_v1.0.2",
+  "name": "vcfeval_hap.py_v1.0.0",
   "summary": "v1.0.0 - Use vcfeval and hap.py to calculate NGS performance metrics against truth set (based on precisionFDA app)",
   "properties": {
-    "github release": "v1.0.2"
+    "github release": "v1.0.0"
   },
-  "dxapi": "1.0.2",
+  "dxapi": "1.0.0",
   "inputSpec": [
     {
       "name": "query_vcf",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "vcfeval_hap.py_v1.0.0",
+  "name": "vcfeval_hap.py_v1.0.2",
   "summary": "v1.0.0 - Use vcfeval and hap.py to calculate NGS performance metrics against truth set (based on precisionFDA app)",
   "properties": {
-    "github release": "v1.0.0"
+    "github release": "v1.0.2"
   },
-  "dxapi": "1.0.0",
+  "dxapi": "1.0.2",
   "inputSpec": [
     {
       "name": "query_vcf",

--- a/src/code.sh
+++ b/src/code.sh
@@ -7,7 +7,7 @@ set -e -x -o pipefail
 dx-download-all-inputs --parallel
 
 #Extract required resources from assets folder into /home/dnanexus/
-dx cat project-F3zxk7Q4F30Xp8fG69K1Vppj:file-F403K904F30y2vpVFqxB9kz7 | gunzip 
+dx cat project-Fjj60Qj4yBGvQXbb5Z6FXkgF:file-Fjp4k3Q4yBGZYpQg3bgpPG95 | tar xf - # ~/hs37d5-fasta.tar -> ~/hs37d5.fa 
 # ~/hs37d5.fa.gz -> ~/hs37d5.fa ~from publicly available project
 dx cat project-Fkb6Gkj433GVVvj73J7x8KbV:file-Fjp4k3j4yBGpK4x73bzbG2P0 | tar xf - 
 # ~/hs37d5-sdf.tar -> ~/hs37d5.sdf/ ~from 001 Reference > genomes > b37

--- a/src/code.sh
+++ b/src/code.sh
@@ -7,7 +7,7 @@ set -e -x -o pipefail
 dx-download-all-inputs --parallel
 
 #Extract required resources from assets folder into /home/dnanexus/
-dx cat project-Fjj60Qj4yBGvQXbb5Z6FXkgF:file-Fjp4k3Q4yBGZYpQg3bgpPG95 | tar xf - 
+dx cat project-Fkb6Gkj433GVVvj73J7x8KbV:file-Fjp4k3Q4yBGZYpQg3bgpPG95 | tar xf - 
 # ~/hs37d5-fasta.tar -> ~/hs37d5.fa ~from 001 Reference > genomes > b37
 dx cat project-Fkb6Gkj433GVVvj73J7x8KbV:file-Fjp4k3j4yBGpK4x73bzbG2P0 | tar xf - 
 # ~/hs37d5-sdf.tar -> ~/hs37d5.sdf/ ~from 001 Reference > genomes > b37

--- a/src/code.sh
+++ b/src/code.sh
@@ -7,8 +7,8 @@ set -e -x -o pipefail
 dx-download-all-inputs --parallel
 
 #Extract required resources from assets folder into /home/dnanexus/
-dx cat project-Fjj60Qj4yBGvQXbb5Z6FXkgF:file-Fjp4k3Q4yBGZYpQg3bgpPG95 | tar xf - # ~/hs37d5-fasta.tar -> ~/hs37d5.fa 
-# ~/hs37d5.fa.gz -> ~/hs37d5.fa ~from publicly available project
+dx cat project-Fjj60Qj4yBGvQXbb5Z6FXkgF:file-Fjp4k3Q4yBGZYpQg3bgpPG95 | tar xf - 
+# ~/hs37d5-fasta.tar -> ~/hs37d5.fa ~from 001 Reference > genomes > b37
 dx cat project-Fkb6Gkj433GVVvj73J7x8KbV:file-Fjp4k3j4yBGpK4x73bzbG2P0 | tar xf - 
 # ~/hs37d5-sdf.tar -> ~/hs37d5.sdf/ ~from 001 Reference > genomes > b37
 dx cat project-Fkb6Gkj433GVVvj73J7x8KbV:file-Fjp4k484yBGb6XyZKgy4gjgb | tar xf - 


### PR DESCRIPTION
gunzip worked, but the public file was not indexed and the job failed with error:
Exception: Fasta file /data/hs37d5.fa is not indexed
So I went back to using the ref file copied into 001. The job ran and output is the same as before migration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcfeval_hap.py/4)
<!-- Reviewable:end -->
